### PR TITLE
Fix for : Error on application deployment not read by screen reader

### DIFF
--- a/webui/src/runtime/com/sun/webui/jsf/renderkit/html/AlertRenderer.java
+++ b/webui/src/runtime/com/sun/webui/jsf/renderkit/html/AlertRenderer.java
@@ -367,6 +367,10 @@ public class AlertRenderer extends AbstractRenderer {
         if (detail != null) {
             writer.startElement("span", alert);
             writer.writeAttribute("class", styles[7], null); //NOI18N
+
+	    //Added to force screen reader to read alert box incase of deployment error
+	    writer.writeAttribute("role", "alert", null);
+
             writer.writeText("\n", null); //NOI18N
             renderFormattedMessage(writer, alert, context, detail);
             writer.endElement("span"); //NOI18N


### PR DESCRIPTION
Adding html role="alert" attribute to force screen reader to read the alert box generated when there is an error in application deployment.
Tested manually using JAWS screen reader.